### PR TITLE
[#5] 로그인 기능 구현 > 로그인 API 구현 및 회원가입 API에 권한 추가

### DIFF
--- a/src/main/java/com/flab/musolmate/common/SecurityConfig.java
+++ b/src/main/java/com/flab/musolmate/common/SecurityConfig.java
@@ -64,7 +64,8 @@ public class SecurityConfig {
 
             /* TODO. 로그인 API와 회원가입 API는 인증에서 제외 */
             .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/auth/**").permitAll() // /members/** 경로는 인증 없이 접근 허용
+                .requestMatchers("/auth/login").permitAll() // 로그인 경로는 인증 없이 접근 허용
+                .requestMatchers("/members").permitAll() // 회원가입 경로는 인증 없이 접근 허용
                 .anyRequest().authenticated() // 그 외 경로는 인증 필요
             )
 

--- a/src/main/java/com/flab/musolmate/common/SecurityConfig.java
+++ b/src/main/java/com/flab/musolmate/common/SecurityConfig.java
@@ -1,12 +1,21 @@
 package com.flab.musolmate.common;
 
+import com.flab.musolmate.common.security.JwtAccessDeniedHandler;
+import com.flab.musolmate.common.security.JwtAuthenticationEntryPoint;
+import com.flab.musolmate.common.security.JwtSecurityConfig;
+import com.flab.musolmate.common.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,9 +28,17 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
  * (https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
  * -> 직접 @Bean으로 등록하여 설정
  */
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true) //@EnableGlobalMethodSecurity 는 deprecated 되었다. @PreAuthorize, @PostAuthorize 등을 사용하기 위해 필요
 public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -30,11 +47,29 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain( HttpSecurity http) throws Exception {
         http
-            .csrf( AbstractHttpConfigurer::disable )                // csrf 비활성화
-            .authorizeHttpRequests( authz -> authz                  // http 접근 제한 설정
-                .requestMatchers( "/members/**" ).permitAll()     // /members/** 경로는 모두 허용
-                .anyRequest().authenticated()                       // 나머지는 인증 필요
-            );
+            .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+
+            .exceptionHandling(exceptionHandling -> exceptionHandling
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 인증 실패 처리
+                .accessDeniedHandler(jwtAccessDeniedHandler)            // 인가 실패 처리
+            )
+
+            .headers(headers -> headers
+                .frameOptions().sameOrigin() // 클릭재킹 방지 설정
+            )
+
+            .sessionManagement(sessionManagement -> sessionManagement
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 정책을 STATELESS로 설정
+            )
+
+            /* TODO. 로그인 API와 회원가입 API는 인증에서 제외 */
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/members/**").permitAll() // /members/** 경로는 인증 없이 접근 허용
+                .anyRequest().authenticated() // 그 외 경로는 인증 필요
+            )
+
+            .apply( new JwtSecurityConfig(tokenProvider) ); // jwtFilter를 addFilterBefore로 등록했던 Configurer를 적용
+
         return http.build();
     }
 

--- a/src/main/java/com/flab/musolmate/common/SecurityConfig.java
+++ b/src/main/java/com/flab/musolmate/common/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
 
             /* TODO. 로그인 API와 회원가입 API는 인증에서 제외 */
             .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/members/**").permitAll() // /members/** 경로는 인증 없이 접근 허용
+                .requestMatchers("/auth/**").permitAll() // /members/** 경로는 인증 없이 접근 허용
                 .anyRequest().authenticated() // 그 외 경로는 인증 필요
             )
 

--- a/src/main/java/com/flab/musolmate/common/SecurityUtil.java
+++ b/src/main/java/com/flab/musolmate/common/SecurityUtil.java
@@ -1,0 +1,35 @@
+package com.flab.musolmate.common;
+
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class SecurityUtil {
+    private static final Logger logger = LoggerFactory.getLogger( SecurityUtil.class);
+
+    /**
+     * Security Context에서 현재 인증정보(Authentication 객체)를 가져와 email을 리턴하는 메소드
+     * @return
+     */
+    public static Optional<String> getCurrentUserEmail() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if ( authentication == null ) {
+            logger.error( "Security Context에 인증 정보가 없습니다." );
+            return Optional.empty();
+        }
+
+        String email = authentication.getName();
+        if ( authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.UserDetails ) {
+            email = ( ( org.springframework.security.core.userdetails.UserDetails ) authentication.getPrincipal() ).getUsername();
+        }
+        else if ( authentication.getPrincipal() instanceof String ) {
+            email = ( String ) authentication.getPrincipal();
+        }
+        return Optional.ofNullable( email );
+    }
+}

--- a/src/main/java/com/flab/musolmate/common/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/flab/musolmate/common/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.flab.musolmate.common.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 필요한 권한이 존재하지 않는 경우 403 Forbidden 에러 리턴
+ */
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle( HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException ) throws IOException, ServletException {
+        response.sendError( HttpServletResponse.SC_FORBIDDEN );
+    }
+}

--- a/src/main/java/com/flab/musolmate/common/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/flab/musolmate/common/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.flab.musolmate.common.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 유효하지 않은 자격 증명시 401 Unauthorized 에러 리턴
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException authException ) throws IOException, ServletException {
+        response.sendError( HttpServletResponse.SC_UNAUTHORIZED );
+    }
+}

--- a/src/main/java/com/flab/musolmate/common/security/JwtFilter.java
+++ b/src/main/java/com/flab/musolmate/common/security/JwtFilter.java
@@ -1,0 +1,64 @@
+package com.flab.musolmate.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+/**
+ * JWT 필터
+ * HTTP 요청으로 들어오는 JWT 토큰의 유효성을 검증하고 현재의 SecurityContext에 JWT 토큰의 인증정보(Authentication)를 저장하는 역할
+ */
+public class JwtFilter extends GenericFilterBean {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private static final Logger logger = LoggerFactory.getLogger( JwtFilter.class );
+
+    private TokenProvider tokenProvider;
+    public JwtFilter( TokenProvider tokenProvider ) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void doFilter( ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain ) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = ( HttpServletRequest ) servletRequest;
+        String jwt = resolveToken( httpServletRequest );
+        String requestURI = httpServletRequest.getRequestURI();
+
+        if ( StringUtils.hasText( jwt ) && tokenProvider.validateToken( jwt ) ) {
+            Authentication authentication = tokenProvider.getAuthentication( jwt );
+            SecurityContextHolder.getContext().setAuthentication( authentication );
+            logger.debug( "Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI );
+        }
+        else {
+            logger.debug( "유효한 JWT 토큰이 없습니다, uri: {}", requestURI );
+        }
+
+        filterChain.doFilter( servletRequest, servletResponse );
+
+    }
+
+    /**
+     * Request Header에서 토큰 정보를 꺼내오기 위한 resolveToken 메소드 추가
+     * @param request
+     * @return
+     */
+    private String resolveToken( HttpServletRequest request ) {
+        String bearerToken = request.getHeader( AUTHORIZATION_HEADER );
+
+        if ( StringUtils.hasText( bearerToken ) && bearerToken.startsWith( "Bearer " ) ) {
+            return bearerToken.substring( 7 );
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/flab/musolmate/common/security/JwtSecurityConfig.java
+++ b/src/main/java/com/flab/musolmate/common/security/JwtSecurityConfig.java
@@ -1,0 +1,23 @@
+package com.flab.musolmate.common.security;
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * UsernamePasswordAuthenticationFilter 앞에 커스텀한 JwtFilter를 추가하기 위한 클래스
+ */
+public class JwtSecurityConfig extends SecurityConfigurerAdapter< DefaultSecurityFilterChain, HttpSecurity > {
+    private final TokenProvider tokenProvider;
+
+    public JwtSecurityConfig( TokenProvider tokenProvider ) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void configure( HttpSecurity http ) throws Exception {
+        JwtFilter customFilter = new JwtFilter( tokenProvider );
+        http.addFilterBefore( customFilter, UsernamePasswordAuthenticationFilter.class );
+    }
+}

--- a/src/main/java/com/flab/musolmate/common/security/TokenProvider.java
+++ b/src/main/java/com/flab/musolmate/common/security/TokenProvider.java
@@ -1,0 +1,145 @@
+package com.flab.musolmate.common.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * JWT 토큰 생성 및 검증
+ *
+ */
+@Slf4j
+@Component
+public class TokenProvider{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    private final String secret;
+    private final long tokenValidityInMilliseconds;
+
+    private Key key;
+
+    public TokenProvider( @Value( "${jwt.secret}" ) String secret,
+                          @Value( "${jwt.token-validity-in-seconds}" ) long tokenValidityInSeconds ) {
+        this.secret = secret;
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+    }
+
+    /**
+     * @PostConstruct가 JSR-250 자바 표준 기술이기 때문에 afterPropertiesSet() 메소드 대신 채택함.
+     * Bean이 생성이 되고 주입을 받은 후에 secret 값을 Base64 Decode해서 key변수에 할당한다.
+     */
+    @PostConstruct
+    public void init() {
+
+        byte[] keyBytes = Decoders.BASE64.decode( secret );
+        this.key = Keys.hmacShaKeyFor( keyBytes );
+    }
+
+    /**
+     * Authentication 객체의 권한정보를 이용해서 토큰을 생성하는 메소드
+     * @param authentication
+     * @return
+     */
+    public String createToken( Authentication authentication) {
+        String authorities = getAuthorities( authentication );
+
+        Date validity = getTokenExpirationDate();
+
+        return createToken( authentication, authorities, validity );
+    }
+
+    /**
+     * Token에 담겨있는 정보를 이용해 Authentication 객체를 리턴하는 메소드
+     * @param token
+     * @return
+     */
+    public Authentication getAuthentication( String token ) {
+        Claims claims = getClaimsFromToken( token );
+
+        Collection<? extends GrantedAuthority> authorities = getAuthoritiesFromClaims( claims );
+
+        User principal = new User( claims.getSubject(), "", authorities );
+
+        return new UsernamePasswordAuthenticationToken( principal, token, authorities ); // 유저정보, 토큰, 권한정보 => Authentication 객체 생성
+    }
+
+    public boolean validateToken( String token ) {
+        try {
+            Jwts.parser().setSigningKey( key ).build().parseClaimsJws( token );
+            return true;
+        }
+        catch ( SecurityException | MalformedJwtException e ) {
+            logger.error( "잘못된 JWT 서명입니다." );
+        }
+        catch ( ExpiredJwtException e ) {
+            logger.error( "만료된 JWT 토큰입니다." );
+        }
+        catch ( IllegalArgumentException e ) {
+            logger.error( "JWT 토큰이 잘못되었습니다." );
+        }
+        return false;
+    }
+
+
+    private String getAuthorities( Authentication authentication ) {
+        return authentication.getAuthorities().stream()
+            .map( GrantedAuthority::getAuthority )
+            .collect( Collectors.joining( "," ) );
+    }
+
+    /**
+     * 토큰 만료시간 = 토큰을 생성한 시간 + 토큰 유효시간
+     * @return
+     */
+    private Date getTokenExpirationDate() {
+        long now = ( System.currentTimeMillis() );
+        return new Date( now + this.tokenValidityInMilliseconds );
+    }
+
+    private String createToken( Authentication authentication, String authorities, Date validity ) {
+        return Jwts.builder()
+            .subject( authentication.getName() ) // setSubject deprecated
+            .claim( "authorities", authorities )
+            .signWith( key, SignatureAlgorithm.HS512 )
+            .expiration( validity ) // setExpiration deprecated
+            .compact();
+    }
+
+
+    private Claims getClaimsFromToken( String token ) {
+        return Jwts.parser()
+            .setSigningKey( key )
+            .build()
+            .parseClaimsJws( token )
+            .getBody();
+    }
+
+    private static List< SimpleGrantedAuthority > getAuthoritiesFromClaims( Claims claims ) {
+        return Arrays.stream( claims.get( AUTHORITIES_KEY ).toString().split( "," ) )
+            .map( SimpleGrantedAuthority::new )
+            .collect( Collectors.toList() );
+    }
+
+
+}

--- a/src/main/java/com/flab/musolmate/common/security/TokenProvider.java
+++ b/src/main/java/com/flab/musolmate/common/security/TokenProvider.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public class TokenProvider{
     private final Logger logger = LoggerFactory.getLogger( this.getClass() );
 
-    private static final String AUTHORITIES_KEY = "auth";
+    private static final String AUTHORITIES_KEY = "authorities";
     private final long tokenValidityInMilliseconds;
 
     private Key key;

--- a/src/main/java/com/flab/musolmate/member/domain/entity/Authority.java
+++ b/src/main/java/com/flab/musolmate/member/domain/entity/Authority.java
@@ -1,0 +1,22 @@
+package com.flab.musolmate.member.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+@Table( name = "authority" )
+public class Authority {
+    @Id
+    @Column(name = "authority_name", length = 50)
+    private String authorityName;
+
+    @Builder
+    public Authority( String authorityName ) {
+        this.authorityName = authorityName;
+    }
+
+}

--- a/src/main/java/com/flab/musolmate/member/domain/entity/Member.java
+++ b/src/main/java/com/flab/musolmate/member/domain/entity/Member.java
@@ -2,20 +2,26 @@ package com.flab.musolmate.member.domain.entity;
 
 import com.flab.musolmate.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Set;
+
 @Getter
 @NoArgsConstructor
 @Entity
+@Table(name = "members")
 public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue( strategy = GenerationType.IDENTITY )
-    @Column( name = "id", nullable = false )
+    @Column( name = "member_id", nullable = false )
     private Long id;
 
+    @NotBlank
+    @Column(unique = true)
     private String email;
 
     @Column( name = "password", nullable = false )
@@ -23,15 +29,23 @@ public class Member extends BaseTimeEntity {
 
     private String nickName;
 
+    @ManyToMany
+    @JoinTable(
+        name = "member_authority",
+        joinColumns = {@JoinColumn(name = "member_id", referencedColumnName = "member_id")},
+        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
+    private Set<Authority> authorities;
+
 // TODO. 음악 엔티티와 연결 필요
 //    private ArrayList<Artist> favoriteArtistList;
 //    private ArrayList<Genre> favoriteGenreList;
 
     @Builder
-    public Member( String email, String password, String nickName ) {
+    public Member( String email, String password, String nickName, Set<Authority> authorities ) {
         this.email = email;
         this.encodedPassword = password;
         this.nickName = nickName;
+        this.authorities = authorities;
     }
 
 }

--- a/src/main/java/com/flab/musolmate/member/domain/repository/AuthorityRepository.java
+++ b/src/main/java/com/flab/musolmate/member/domain/repository/AuthorityRepository.java
@@ -1,0 +1,7 @@
+package com.flab.musolmate.member.domain.repository;
+
+import com.flab.musolmate.member.domain.entity.Authority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthorityRepository extends JpaRepository< Authority, String> {
+}

--- a/src/main/java/com/flab/musolmate/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/flab/musolmate/member/domain/repository/MemberRepository.java
@@ -1,10 +1,21 @@
 package com.flab.musolmate.member.domain.repository;
 
 import com.flab.musolmate.member.domain.entity.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository< Member, Long> {
     boolean existsByEmail( String email );
 
     boolean existsByNickName( String nickName );
+
+    /**
+     * email 기준으로 Member 조회. 권한 정보도 같이 조회
+     * @param email
+     * @return
+     */
+    @EntityGraph(attributePaths = "authorities") // Eager 조회로 쿼리 수행
+    Optional<Member> findOneWithAuthoritiesByEmail( String email );
 }

--- a/src/main/java/com/flab/musolmate/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/flab/musolmate/member/domain/repository/MemberRepository.java
@@ -18,4 +18,7 @@ public interface MemberRepository extends JpaRepository< Member, Long> {
      */
     @EntityGraph(attributePaths = "authorities") // Eager 조회로 쿼리 수행
     Optional<Member> findOneWithAuthoritiesByEmail( String email );
+
+    @EntityGraph(attributePaths = "authorities") // Eager 조회로 쿼리 수행
+    Optional<Member> findOneWithAuthoritiesById( Long id );
 }

--- a/src/main/java/com/flab/musolmate/member/service/CustomUserDetailService.java
+++ b/src/main/java/com/flab/musolmate/member/service/CustomUserDetailService.java
@@ -1,0 +1,39 @@
+package com.flab.musolmate.member.service;
+
+import com.flab.musolmate.member.domain.entity.Member;
+import com.flab.musolmate.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component( "userDetailsService" )
+public class CustomUserDetailService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Transactional // 왜 썼을까 알아보기 -> DB에서 Member 정보와 권한 정보 두가지 모두 가져와야 하기 때문에 트랜잭션 사용
+    @Override // parameter는 왜 final을 추가했을까 -> 변수에 final을 붙이면 재할당이 불가하다. 로그인에 사용되는 중요한 정보이기 때문에 재할당이 불가하도록 final을 붙인 것 같다.
+    public UserDetails loadUserByUsername( final String email ) {
+        return memberRepository.findOneWithAuthoritiesByEmail( email )
+                                .map( member -> createMember( email, member) )
+                                .orElseThrow( () -> new UsernameNotFoundException( email + " -> 데이터베이스에서 찾을 수 없습니다." ) );
+    }
+
+    private org.springframework.security.core.userdetails.User createMember(String email, Member member) {
+        List< GrantedAuthority > grantedAuthorities = member.getAuthorities().stream()
+                                                            .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+                                                            .collect( Collectors.toList());
+
+        return new org.springframework.security.core.userdetails.User(member.getEmail(),
+                                                                    member.getEncodedPassword(),
+                                                                    grantedAuthorities);
+    }
+}

--- a/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
+++ b/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
@@ -3,7 +3,7 @@ package com.flab.musolmate.member.service;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
 import com.flab.musolmate.member.exception.DuplicateMemberException;
-import com.flab.musolmate.member.web.dto.MemberRegisterRequest;
+import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
+++ b/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
@@ -1,5 +1,6 @@
 package com.flab.musolmate.member.service;
 
+import com.flab.musolmate.common.SecurityUtil;
 import com.flab.musolmate.member.domain.entity.Authority;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -34,6 +36,26 @@ public class MemberBasicService {
         Authority userAuthority = makeUserAuthority();
 
         return memberRepository.save( requestDto.toEntity( passwordEncoder.encode( requestDto.getPassword() ), Collections.singleton( userAuthority ) ) );
+    }
+
+
+    /**
+     * Member의 id로 회원 정보와 해당 회원의 권한 정보 조회
+     * @param id
+     * @return
+     */
+    @Transactional(readOnly = true) // 성능 향상을 위해 readOnly = true로 설정한다는데 정말 큰 차이가 있을까?
+    public Optional<Member> getMemberWithAuthorities( Long id ) {
+        return memberRepository.findOneWithAuthoritiesById( id );
+    }
+
+    /**
+     * 현재 SecurityContext에 저장된 회원 정보와 해당 회원의 권한 정보 조회
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public Optional<Member> getMyMemberWithAthorities() {
+        return SecurityUtil.getCurrentUserEmail().flatMap( memberRepository::findOneWithAuthoritiesByEmail );
     }
 
     private void checkDuplicateEmailAndNickName( MemberRegisterRequest requestDto ) {

--- a/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
+++ b/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
@@ -1,5 +1,6 @@
 package com.flab.musolmate.member.service;
 
+import com.flab.musolmate.member.domain.entity.Authority;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
 import com.flab.musolmate.member.exception.DuplicateMemberException;
@@ -9,9 +10,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+
 @RequiredArgsConstructor
 @Service
 public class MemberBasicService {
+    public static final String AUTHORITY_NAME_USER = "ROLE_USER"; // TODO. enum으로 변경
+    public static final String AUTHORITY_NAME_ADMIN = "ROLE_ADMIN"; // TODO. enum으로 변경
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -26,16 +31,25 @@ public class MemberBasicService {
         /* 클라이언트에서 하겠지만 서버에서 한번 더 체크 */
         checkDuplicateEmailAndNickName( requestDto );
 
-        return memberRepository.save( requestDto.toEntity( passwordEncoder.encode( requestDto.getPassword() ) ) );
+        Authority userAuthority = makeUserAuthority();
+
+        return memberRepository.save( requestDto.toEntity( passwordEncoder.encode( requestDto.getPassword() ), Collections.singleton( userAuthority ) ) );
     }
 
     private void checkDuplicateEmailAndNickName( MemberRegisterRequest requestDto ) {
 
-        if ( memberRepository.existsByEmail( requestDto.getEmail() ) ) {
-            throw new DuplicateMemberException( "이미 존재하는 이메일입니다." );
+        if ( memberRepository.findOneWithAuthoritiesByEmail( requestDto.getEmail() ).orElse( null ) != null ) {
+            throw new DuplicateMemberException( "이미 가입한 회원입니다." );
         }
         if ( memberRepository.existsByNickName( requestDto.getNickName() ) ) {
             throw new DuplicateMemberException( "이미 존재하는 닉네임입니다." );
         }
+    }
+
+    private Authority makeUserAuthority() {
+
+        return Authority.builder()
+            .authorityName( AUTHORITY_NAME_USER )
+            .build();
     }
 }

--- a/src/main/java/com/flab/musolmate/member/web/AuthController.java
+++ b/src/main/java/com/flab/musolmate/member/web/AuthController.java
@@ -1,0 +1,42 @@
+package com.flab.musolmate.member.web;
+
+import com.flab.musolmate.common.security.TokenProvider;
+import com.flab.musolmate.member.web.request.LoginRequest;
+import com.flab.musolmate.member.web.response.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    // 로그인 성공시 토큰 발급
+    private final TokenProvider tokenProvider;
+    // 유저 정보를 가져오기 위한 AuthenticationManagerBuilder
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @PostMapping("/login")
+    public ResponseEntity< LoginResponse > emailLogin( @Valid @RequestBody LoginRequest loginRequest ){
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken( loginRequest.getEmail(), loginRequest.getPassword() );
+
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate( authenticationToken );
+        SecurityContextHolder.getContext().setAuthentication( authentication );
+
+        LoginResponse response = tokenProvider.createLoginResponse( authentication );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add( HttpHeaders.AUTHORIZATION, "Bearer " + response.getToken() );
+
+        return ResponseEntity.ok().headers( headers ).body( response );
+    }
+}

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -7,10 +7,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -28,6 +26,12 @@ public class MemberApiController {
 
         Member registeredMember = memberBasicService.registerMember( requestDto );
         return new ResponseEntity<>( registeredMember, HttpStatus.CREATED );
+    }
+
+    @GetMapping("/hello")
+    @PreAuthorize( "hasAnyAuthority('ROLE_USER')" )
+    public String hello() {
+        return "hello";
     }
 
 

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -2,7 +2,7 @@ package com.flab.musolmate.member.web;
 
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.service.MemberBasicService;
-import com.flab.musolmate.member.web.dto.MemberRegisterRequest;
+import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -28,11 +28,19 @@ public class MemberApiController {
         return new ResponseEntity<>( registeredMember, HttpStatus.CREATED );
     }
 
-    @GetMapping("/hello")
-    @PreAuthorize( "hasAnyAuthority('ROLE_USER')" )
-    public String hello() {
-        return "hello";
+    @GetMapping("/{id}")
+    @PreAuthorize( "hasAnyAuthority('ROLE_ADMIN')" )
+    public ResponseEntity<Member> getMember( @PathVariable Long id ) {
+        Member member = memberBasicService.getMemberWithAuthorities( id ).orElse( null );
+        if ( member == null ) {
+            return new ResponseEntity<>( HttpStatus.NOT_FOUND ); // TODO. 커스텀 예외 처리
+        }
+        return ResponseEntity.ok( member );
     }
 
-
+    @GetMapping("/me")
+    @PreAuthorize( "hasAnyAuthority('ROLE_USER')" )
+    public ResponseEntity<Member> getMyMember() {
+        return ResponseEntity.ok( memberBasicService.getMyMemberWithAthorities().get() );
+    }
 }

--- a/src/main/java/com/flab/musolmate/member/web/request/LoginRequest.java
+++ b/src/main/java/com/flab/musolmate/member/web/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.flab.musolmate.member.web.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
+++ b/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
@@ -20,6 +20,7 @@ public class MemberRegisterRequest {
     @Email(message = "이메일 형식에 맞게 입력해주세요.")
     private String email;
 
+//    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) // TODO. 왜 junit으로 가입시 비밀번호가 null로 들어가는지 확인
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
     private String password;

--- a/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
+++ b/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.flab.musolmate.member.web.dto;
+package com.flab.musolmate.member.web.request;
 
 import com.flab.musolmate.member.domain.entity.Member;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
+++ b/src/main/java/com/flab/musolmate/member/web/request/MemberRegisterRequest.java
@@ -1,10 +1,13 @@
 package com.flab.musolmate.member.web.request;
 
+import com.flab.musolmate.member.domain.entity.Authority;
 import com.flab.musolmate.member.domain.entity.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.util.Set;
 
 /**
  * 회원가입 요청 DTO
@@ -31,11 +34,12 @@ public class MemberRegisterRequest {
         this.password = password;
         this.nickName = nickName;
     }
-    public Member toEntity( String encodedPassword ) {
+    public Member toEntity( String encodedPassword, Set< Authority > authorities ) {
         return Member.builder()
             .email(email)
             .password(encodedPassword)
             .nickName(nickName)
+            .authorities( authorities )
             .build();
     }
 }

--- a/src/main/java/com/flab/musolmate/member/web/response/LoginResponse.java
+++ b/src/main/java/com/flab/musolmate/member/web/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.flab.musolmate.member.web.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming( PropertyNamingStrategies.SnakeCaseStrategy.class)
+@AllArgsConstructor
+@Getter
+@Builder
+public class LoginResponse {
+    private String token;
+    private Long tokenExpired;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,5 +16,5 @@ spring.jpa.properties.hibernate.format_sql=true
 # spring security (HS512 -> more than 64 bytes)
 jwt.header=Authorization
 jwt.secret=ZmxhYi1tdXNpYy1zb3VsbWF0ZS1ieS1ncmV5LXVzaW5nLWpzb24td2ViLXRva2VuCg==
-jwt.expiration=300000
+jwt.token-validity-in-seconds=3600
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+logging.level.com.flab=debug
+
 # spring datasource (H2)
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
@@ -12,6 +14,8 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.generate-ddl=false
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
 
 # spring security (HS512 -> more than 64 bytes)
 jwt.header=Authorization

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,5 @@ spring.sql.init.mode=always
 
 # spring security (HS512 -> more than 64 bytes)
 jwt.header=Authorization
-jwt.secret=ZmxhYi1tdXNpYy1zb3VsbWF0ZS1ieS1ncmV5LXVzaW5nLWpzb24td2ViLXRva2VuCg==
 jwt.token-validity-in-seconds=3600
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,7 @@
-insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('admin@gmail.com', '$2a$10$F2JsXoyV3Ws9o6m1wmGaC.d5QT9pK6rNLpgwbCEQH1JuXm4HD6On6', 'admin');
-insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('user@gmail.com', '$2a$10$H/EjQ8dAfcozoIpDyLLk8.85ifHFUbZwKoUcZqQ5enEES8p/NwJzO', 'user');
+insert into MEMBERS ( EMAIL, PASSWORD, NICK_NAME) values ('admin@gmail.com', '$2a$10$F2JsXoyV3Ws9o6m1wmGaC.d5QT9pK6rNLpgwbCEQH1JuXm4HD6On6', 'admin');
 
 insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_USER');
 insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_ADMIN');
 
 insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (1, 'ROLE_USER');
 insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (1, 'ROLE_ADMIN');
-insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (2, 'ROLE_USER');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,9 @@
+insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('admin@gmail.com', '$2a$08$lDnHPz7eUkSi6ao14Twuau08mzhWrL4kyZGGU5xfiGALO/Vxd5DOi', 'admin');
+insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('user@gmail.com', '$2a$08$UkVvwpULis18S19S5pZFn.YHPZt3oaqHZnDwqbCW9pft6uFtkXKDC', 'user');
+
+insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_USER');
+insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_ADMIN');
+
+insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (1, 'ROLE_USER');
+insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (1, 'ROLE_ADMIN');
+insert into MEMBER_AUTHORITY (MEMBER_ID, AUTHORITY_NAME) values (2, 'ROLE_USER');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('admin@gmail.com', '$2a$08$lDnHPz7eUkSi6ao14Twuau08mzhWrL4kyZGGU5xfiGALO/Vxd5DOi', 'admin');
-insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('user@gmail.com', '$2a$08$UkVvwpULis18S19S5pZFn.YHPZt3oaqHZnDwqbCW9pft6uFtkXKDC', 'user');
+insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('admin@gmail.com', '$2a$10$F2JsXoyV3Ws9o6m1wmGaC.d5QT9pK6rNLpgwbCEQH1JuXm4HD6On6', 'admin');
+insert into MEMBERS (EMAIL, PASSWORD, NICK_NAME) values ('user@gmail.com', '$2a$10$H/EjQ8dAfcozoIpDyLLk8.85ifHFUbZwKoUcZqQ5enEES8p/NwJzO', 'user');
 
 insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_USER');
 insert into AUTHORITY (AUTHORITY_NAME) values ('ROLE_ADMIN');

--- a/src/test/java/com/flab/musolmate/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/flab/musolmate/member/domain/repository/MemberRepositoryTest.java
@@ -120,4 +120,23 @@ public class MemberRepositoryTest {
 
     }
 
+    @Test
+    public void memberId_기준으로_Member_조회() {
+        // given
+        memberRepository.save( memberA );
+        authorityRepository.save( authUser );
+
+        // when
+        Member member = memberRepository.findOneWithAuthoritiesById( memberA.getId() )
+            .orElseThrow( () -> new IllegalArgumentException( "해당 유저가 없습니다." ) );
+
+        // then
+        assertThat( member.getEmail() ).isEqualTo( memberA.getEmail() );
+
+        member.getAuthorities().forEach( authority -> {
+            assertThat( authority.getAuthorityName() ).isEqualTo( authUser.getAuthorityName() );
+        } );
+
+    }
+
 }

--- a/src/test/java/com/flab/musolmate/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/flab/musolmate/member/domain/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.flab.musolmate.member.domain.repository;
 
+import com.flab.musolmate.member.domain.entity.Authority;
 import com.flab.musolmate.member.domain.entity.Member;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,14 +21,23 @@ public class MemberRepositoryTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    AuthorityRepository authorityRepository;
+
     Member memberA;
+    Authority authUser;
 
     @BeforeEach
     public void setup() {
+        authUser = Authority.builder()
+            .authorityName( "ROLE_USER" )
+            .build();
+
         memberA = Member.builder()
             .email( "aaa@gmail.com" )
             .password( "1234qwer" )
             .nickName( "aaa" )
+            .authorities( Set.of( authUser ) )
             .build();
     }
 
@@ -88,6 +99,25 @@ public class MemberRepositoryTest {
         System.out.println( ">>>>>>>>> createDate=" + member.getCreatedDate() + ", modifiedDate=" + member.getModifiedDate() );
         assertThat( member.getCreatedDate() ).isAfter( now );
         assertThat( member.getModifiedDate() ).isAfter( now );
+    }
+
+    @Test
+    public void email_기준으로_Member_조회() {
+        // given
+        memberRepository.save( memberA );
+        authorityRepository.save( authUser );
+
+        // when
+        Member member = memberRepository.findOneWithAuthoritiesByEmail( memberA.getEmail() )
+            .orElseThrow( () -> new IllegalArgumentException( "해당 유저가 없습니다." ) );
+
+        // then
+        assertThat( member.getEmail() ).isEqualTo( memberA.getEmail() );
+
+        member.getAuthorities().forEach( authority -> {
+            assertThat( authority.getAuthorityName() ).isEqualTo( authUser.getAuthorityName() );
+        } );
+
     }
 
 }

--- a/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
+++ b/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
@@ -6,6 +6,7 @@ import com.flab.musolmate.member.exception.DuplicateMemberException;
 import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -75,7 +76,7 @@ class MemberBasicServiceTest {
         // when
         assertThatThrownBy( () -> memberBasicService.registerMember( requestDto ) )
             .isInstanceOf( DuplicateMemberException.class )
-            .hasMessageContaining( "이미 존재하는 이메일입니다." );
+            .hasMessageContaining( "이미 가입한 회원입니다." );
 
     }
 
@@ -99,6 +100,24 @@ class MemberBasicServiceTest {
             .isInstanceOf( DuplicateMemberException.class )
             .hasMessageContaining( "이미 존재하는 닉네임입니다." );
 
+    }
+
+    @Test
+    @DisplayName( "Member의 id로 권한 정보를 포함한 회원 정보를 조회할 수 있다" )
+    public void 회원정보_조회(){
+        // given
+        Member registeredMember = memberBasicService.registerMember( requestDto );
+        assertThat( registeredMember.getId() ).isNotNull();
+        assertThat( registeredMember.getEmail() ).isEqualTo( requestDto.getEmail() );
+
+        // when
+        Member member = memberBasicService.getMemberWithAuthorities( registeredMember.getId() ).get();
+
+        // then
+        assertThat( member.getId() ).isEqualTo( registeredMember.getId() );
+        assertThat( member.getEmail() ).isEqualTo( registeredMember.getEmail() );
+        assertThat( member.getEncodedPassword() ).isEqualTo( registeredMember.getEncodedPassword() );
+        assertThat( member.getNickName() ).isEqualTo( registeredMember.getNickName() );
     }
 
 }

--- a/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
+++ b/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
@@ -3,7 +3,7 @@ package com.flab.musolmate.member.service;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
 import com.flab.musolmate.member.exception.DuplicateMemberException;
-import com.flab.musolmate.member.web.dto.MemberRegisterRequest;
+import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
@@ -77,10 +77,19 @@ public class MemberApiControllerTest {
 
         // then
         assertThat( responseEntity.getStatusCode() ).isEqualTo( HttpStatus.CREATED );
-        List< Member > all = memberRepository.findAll();
-        assertThat( all.get( 0 ).getEmail() ).isEqualTo( email );
-        assertThat( passwordEncoder.matches( password, all.get( 0 ).getEncodedPassword() ) ).isTrue();
-        assertThat( all.get( 0 ).getNickName() ).isEqualTo( nickName );
+
+        memberRepository.findOneWithAuthoritiesByEmail( email )
+            .ifPresent(
+                member -> {
+                    assertThat( member.getEmail() ).isEqualTo( email );
+                    assertThat( passwordEncoder.matches( password, member.getEncodedPassword() ) ).isTrue();
+                    assertThat( member.getNickName() ).isEqualTo( nickName );
+
+                    member.getAuthorities().forEach( authority -> {
+                        assertThat( authority.getAuthorityName() ).isEqualTo( "ROLE_USER" );
+                    });
+            });
+
     }
 
 }

--- a/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
@@ -2,7 +2,7 @@ package com.flab.musolmate.member.web;
 
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
-import com.flab.musolmate.member.web.dto.MemberRegisterRequest;
+import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
@@ -3,7 +3,7 @@ package com.flab.musolmate.member.web;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.domain.repository.MemberRepository;
 import com.flab.musolmate.member.web.request.MemberRegisterRequest;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,7 +32,7 @@ public class MemberApiControllerTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @AfterEach
+    @BeforeEach
     public void tearDown() throws Exception {
         memberRepository.deleteAll();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
-  #5

## 📝작업 내용
### JWT 관련 클래스 추가 및 Config 설정
- TokenProvider 생성 (a1450974)
- JwtFilter 생성 (fc6aa68c)
- JwtSecurityConfig, Security관련 에러 클래스 생성 (f2986704)
- SecurityConfig에 JWT 관련 설정 적용 (1de35b90)

### 데이터 관련
- Member 엔티티에 Authority 엔티티 맵핑 (83dedc6c)

### API 기능
- 로그인 API 작성(6cbc7e2c)
- 회원가입 API 수정(0c768ff1)
- 권한 적용 여부 확인을 위한 회원 조회 API 추가(692d1f76)
