### PR TITLE
[#12] 공통 응답 형식 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target/
 *.iws
 *.iml
 *.ipr
+out/
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/flab/musolmate/common/ExceptionAdvice.java
+++ b/src/main/java/com/flab/musolmate/common/ExceptionAdvice.java
@@ -2,6 +2,7 @@ package com.flab.musolmate.common;
 
 import com.flab.musolmate.common.domain.api.ApiResponse;
 import com.flab.musolmate.member.exception.DuplicateMemberException;
+import com.flab.musolmate.member.exception.NotFoundMemberException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,10 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler( DuplicateMemberException.class )
     public ResponseEntity< ApiResponse< ? > > DuplicateMemberException( RuntimeException exception ) {
         return ResponseEntity.status( HttpStatus.CONFLICT ).body( ApiResponse.createError( HttpStatus.CONFLICT.value(), exception.getMessage() ) );
+    }
+    @ExceptionHandler( NotFoundMemberException.class )
+    public ResponseEntity< ApiResponse< ? > > NotFoundMemberException( RuntimeException exception ) {
+        return ResponseEntity.status( HttpStatus.NOT_FOUND ).body( ApiResponse.createError( HttpStatus.NOT_FOUND.value(), exception.getMessage() ) );
     }
 
     @ExceptionHandler( { AuthenticationException.class } )

--- a/src/main/java/com/flab/musolmate/common/SecurityConfig.java
+++ b/src/main/java/com/flab/musolmate/common/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
             /* TODO. 로그인 API와 회원가입 API는 인증에서 제외 */
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/auth/login").permitAll() // 로그인 경로는 인증 없이 접근 허용
-                .requestMatchers("/members").permitAll() // 회원가입 경로는 인증 없이 접근 허용
+                .requestMatchers("/members/register").permitAll() // 회원가입 경로는 인증 없이 접근 허용
                 .anyRequest().authenticated() // 그 외 경로는 인증 필요
             )
 

--- a/src/main/java/com/flab/musolmate/common/domain/api/ApiResponse.java
+++ b/src/main/java/com/flab/musolmate/common/domain/api/ApiResponse.java
@@ -1,0 +1,53 @@
+package com.flab.musolmate.common.domain.api;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class ApiResponse<T> {
+    private static final String STATUS_SUCCESS = "success";
+    private static final String STATUS_FAIL = "fail";
+    private static final String STATUS_ERROR = "error";
+
+    private String status;
+    private int code;
+    private T data;
+
+    public ApiResponse( String status, int code, T data ) {
+        this.status = status;
+        this.code = code;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> createSuccess( T data ) {
+        return new ApiResponse<>( STATUS_SUCCESS, HttpStatus.OK.value(), data );
+    }
+
+    public static ApiResponse< ? > createFail( int statusCode, BindingResult bindingResult ) {
+        Map< String, String > errors = new HashMap<>();
+
+        List< ObjectError > allErrors = bindingResult.getAllErrors();
+        for ( ObjectError error : allErrors ) {
+
+            if ( error instanceof FieldError ) {
+                errors.put( ( ( FieldError ) error ).getField(), error.getDefaultMessage() );
+            }
+            else {
+                errors.put( error.getObjectName(), error.getDefaultMessage() );
+            }
+        }
+        return new ApiResponse<>( STATUS_FAIL, statusCode, errors );
+    }
+
+    public static ApiResponse<?> createError( int statusCode, String message) {
+        return new ApiResponse<>( STATUS_ERROR, statusCode, message);
+    }
+
+}

--- a/src/main/java/com/flab/musolmate/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/flab/musolmate/common/exception/ExceptionAdvice.java
@@ -1,4 +1,4 @@
-package com.flab.musolmate.common;
+package com.flab.musolmate.common.exception;
 
 import com.flab.musolmate.common.domain.api.ApiResponse;
 import com.flab.musolmate.member.exception.DuplicateMemberException;
@@ -19,40 +19,47 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import java.util.*;
 
+import static com.flab.musolmate.common.exception.ExceptionEnum.*;
+
 @RestControllerAdvice
 @Slf4j
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity< Object > handleMethodArgumentNotValid( MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request ) {
-        return ResponseEntity.status( HttpStatus.BAD_REQUEST ).body( ApiResponse.createFail( HttpStatus.BAD_REQUEST.value(), ex.getBindingResult() ) );
+        String objectName = ex.getBindingResult().getObjectName();
+        int statusCode = METHOD_ARGUMENT_NOT_VALID_EXCEPTION.getStatusCode();
+        if ( objectName.startsWith( "member" ) ) {
+            statusCode = METHOD_ARGUMENT_MEMBER_NOT_VALID_EXCEPTION.getStatusCode();
+        }
+        return ResponseEntity.status( HttpStatus.BAD_REQUEST ).body( ApiResponse.createFail( statusCode, ex.getBindingResult() ) );
     }
 
     @ExceptionHandler( DuplicateMemberException.class )
     public ResponseEntity< ApiResponse< ? > > DuplicateMemberException( RuntimeException exception ) {
-        return ResponseEntity.status( HttpStatus.CONFLICT ).body( ApiResponse.createError( HttpStatus.CONFLICT.value(), exception.getMessage() ) );
+        return ResponseEntity.status( HttpStatus.CONFLICT ).body( ApiResponse.createError( DUPLICATE_MEMBER_EXCEPTION.getStatusCode(), exception.getMessage() ) );
     }
     @ExceptionHandler( NotFoundMemberException.class )
     public ResponseEntity< ApiResponse< ? > > NotFoundMemberException( RuntimeException exception ) {
-        return ResponseEntity.status( HttpStatus.NOT_FOUND ).body( ApiResponse.createError( HttpStatus.NOT_FOUND.value(), exception.getMessage() ) );
+        return ResponseEntity.status( HttpStatus.NOT_FOUND ).body( ApiResponse.createError( NOT_FOUND_MEMBER_EXCEPTION.getStatusCode(), exception.getMessage() ) );
     }
 
     @ExceptionHandler( { AuthenticationException.class } )
     @ResponseBody
     public ResponseEntity< ApiResponse< ? > > handleAuthenticationException( AuthenticationException ex ) {
-        return ResponseEntity.status( HttpStatus.UNAUTHORIZED ).body( ApiResponse.createError( HttpStatus.UNAUTHORIZED.value(), ex.getMessage() ) );
+        return ResponseEntity.status( HttpStatus.UNAUTHORIZED ).body( ApiResponse.createError( UNAUTHORIZED_EXCEPTION.getStatusCode(), ex.getMessage() ) );
 
     }
 
     @ExceptionHandler( { AccessDeniedException.class } )
     @ResponseBody
     public ResponseEntity< ApiResponse< ? > > handleAccessDeniedException( AccessDeniedException ex ) {
-        return ResponseEntity.status( HttpStatus.FORBIDDEN ).body( ApiResponse.createError( HttpStatus.FORBIDDEN.value(), ex.getMessage() ) );
+        return ResponseEntity.status( HttpStatus.FORBIDDEN ).body( ApiResponse.createError( FORBIDDEN_EXCEPTION.getStatusCode(), ex.getMessage() ) );
 
     }
 
     @ExceptionHandler( Exception.class )
     public ResponseEntity< ApiResponse< ? > > handleException( Exception ex ) {
         log.error( "Exception", ex );
-        return ResponseEntity.status( HttpStatus.INTERNAL_SERVER_ERROR ).body( ApiResponse.createError( HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage() ) );
+        return ResponseEntity.status( HttpStatus.INTERNAL_SERVER_ERROR ).body( ApiResponse.createError( INTERNAL_SERVER_ERROR.getStatusCode(), ex.getMessage() ) );
     }
 }

--- a/src/main/java/com/flab/musolmate/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/flab/musolmate/common/exception/ExceptionEnum.java
@@ -1,0 +1,24 @@
+package com.flab.musolmate.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionEnum {
+
+        UNAUTHORIZED_EXCEPTION(40100 ),
+        FORBIDDEN_EXCEPTION(40300 ),
+        INTERNAL_SERVER_ERROR(50000 ),
+        METHOD_ARGUMENT_NOT_VALID_EXCEPTION(40000 ),
+
+        // Member관련 : XXX01
+        METHOD_ARGUMENT_MEMBER_NOT_VALID_EXCEPTION(40001 ),
+        DUPLICATE_MEMBER_EXCEPTION(40901 ),
+        NOT_FOUND_MEMBER_EXCEPTION(40401 );
+
+
+        private final int statusCode;
+
+        ExceptionEnum(int statusCode) {
+            this.statusCode = statusCode;
+        }
+}

--- a/src/main/java/com/flab/musolmate/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/flab/musolmate/common/exception/ExceptionEnum.java
@@ -15,6 +15,8 @@ public enum ExceptionEnum {
         DUPLICATE_MEMBER_EXCEPTION(40901 ),
         NOT_FOUND_MEMBER_EXCEPTION(40401 );
 
+        public static final String MESSAGE_DUPLICATE_MEMBER_EXCEPTION_EMAIL = "이미 존재하는 이메일입니다.";
+        public static final String MESSAGE_DUPLICATE_MEMBER_EXCEPTION_NICKNAME = "이미 존재하는 닉네임입니다.";
 
         private final int statusCode;
 

--- a/src/main/java/com/flab/musolmate/member/exception/NotFoundMemberException.java
+++ b/src/main/java/com/flab/musolmate/member/exception/NotFoundMemberException.java
@@ -1,0 +1,8 @@
+package com.flab.musolmate.member.exception;
+
+public class NotFoundMemberException extends RuntimeException {
+
+    public NotFoundMemberException( String message ) {
+        super( message );
+    }
+}

--- a/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
+++ b/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
@@ -61,7 +61,7 @@ public class MemberBasicService {
     private void checkDuplicateEmailAndNickName( MemberRegisterRequest requestDto ) {
 
         if ( memberRepository.findOneWithAuthoritiesByEmail( requestDto.getEmail() ).orElse( null ) != null ) {
-            throw new DuplicateMemberException( "이미 가입한 회원입니다." );
+            throw new DuplicateMemberException( "이미 존재하는 이메일입니다." );
         }
         if ( memberRepository.existsByNickName( requestDto.getNickName() ) ) {
             throw new DuplicateMemberException( "이미 존재하는 닉네임입니다." );

--- a/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
+++ b/src/main/java/com/flab/musolmate/member/service/MemberBasicService.java
@@ -14,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.Optional;
 
+import static com.flab.musolmate.common.exception.ExceptionEnum.MESSAGE_DUPLICATE_MEMBER_EXCEPTION_EMAIL;
+import static com.flab.musolmate.common.exception.ExceptionEnum.MESSAGE_DUPLICATE_MEMBER_EXCEPTION_NICKNAME;
+
 @RequiredArgsConstructor
 @Service
 public class MemberBasicService {
@@ -61,10 +64,10 @@ public class MemberBasicService {
     private void checkDuplicateEmailAndNickName( MemberRegisterRequest requestDto ) {
 
         if ( memberRepository.findOneWithAuthoritiesByEmail( requestDto.getEmail() ).orElse( null ) != null ) {
-            throw new DuplicateMemberException( "이미 존재하는 이메일입니다." );
+            throw new DuplicateMemberException( MESSAGE_DUPLICATE_MEMBER_EXCEPTION_EMAIL );
         }
         if ( memberRepository.existsByNickName( requestDto.getNickName() ) ) {
-            throw new DuplicateMemberException( "이미 존재하는 닉네임입니다." );
+            throw new DuplicateMemberException( MESSAGE_DUPLICATE_MEMBER_EXCEPTION_NICKNAME );
         }
     }
 

--- a/src/main/java/com/flab/musolmate/member/web/AuthController.java
+++ b/src/main/java/com/flab/musolmate/member/web/AuthController.java
@@ -1,11 +1,13 @@
 package com.flab.musolmate.member.web;
 
+import com.flab.musolmate.common.domain.api.ApiResponse;
 import com.flab.musolmate.common.security.TokenProvider;
 import com.flab.musolmate.member.web.request.LoginRequest;
 import com.flab.musolmate.member.web.response.LoginResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -15,17 +17,18 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/auth")
+@RequestMapping( "/auth" )
 public class AuthController {
     // 로그인 성공시 토큰 발급
     private final TokenProvider tokenProvider;
     // 유저 정보를 가져오기 위한 AuthenticationManagerBuilder
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
-    @PostMapping("/login")
-    public ResponseEntity< LoginResponse > emailLogin( @Valid @RequestBody LoginRequest loginRequest ){
+    @PostMapping( "/login" )
+    public ResponseEntity< ApiResponse< LoginResponse > > emailLogin( @Valid @RequestBody LoginRequest loginRequest ) {
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken( loginRequest.getEmail(), loginRequest.getPassword() );
 
@@ -37,6 +40,6 @@ public class AuthController {
         HttpHeaders headers = new HttpHeaders();
         headers.add( HttpHeaders.AUTHORIZATION, "Bearer " + response.getToken() );
 
-        return ResponseEntity.ok().headers( headers ).body( response );
+        return ResponseEntity.status( HttpStatus.OK ).headers( headers ).body( ApiResponse.createSuccess( response ) );
     }
 }

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -2,6 +2,7 @@ package com.flab.musolmate.member.web;
 
 import com.flab.musolmate.common.domain.api.ApiResponse;
 import com.flab.musolmate.member.domain.entity.Member;
+import com.flab.musolmate.member.exception.NotFoundMemberException;
 import com.flab.musolmate.member.service.MemberBasicService;
 import com.flab.musolmate.member.web.request.MemberRegisterRequest;
 import jakarta.validation.Valid;
@@ -33,17 +34,14 @@ public class MemberApiController {
     @GetMapping( "/{id}" )
     @PreAuthorize( "hasAnyAuthority('ROLE_ADMIN')" )
     public ResponseEntity< ApiResponse< Member > > getMember( @PathVariable Long id ) {
-        Member member = memberBasicService.getMemberWithAuthorities( id ).orElse( null );
-        if ( member == null ) {
-            return new ResponseEntity<>( HttpStatus.NOT_FOUND ); // TODO. 커스텀 예외 처리
-        }
+        Member member = memberBasicService.getMemberWithAuthorities( id ).orElseThrow( () -> new NotFoundMemberException( "회원 정보가 존재하지 않습니다." ) );
         return ResponseEntity.status( HttpStatus.OK ).body( ApiResponse.createSuccess( member ) );
     }
 
     @GetMapping( "/me" )
     @PreAuthorize( "hasAnyAuthority('ROLE_USER')" )
     public ResponseEntity< ApiResponse< Member > > getMyMember() {
-        Member member = memberBasicService.getMyMemberWithAthorities().orElse( null );
+        Member member = memberBasicService.getMyMemberWithAthorities().orElseThrow( () -> new NotFoundMemberException( "회원 정보가 존재하지 않습니다." ) );
         return ResponseEntity.status( HttpStatus.OK ).body( ApiResponse.createSuccess( member ) );
     }
 }

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -1,5 +1,6 @@
 package com.flab.musolmate.member.web;
 
+import com.flab.musolmate.common.domain.api.ApiResponse;
 import com.flab.musolmate.member.domain.entity.Member;
 import com.flab.musolmate.member.service.MemberBasicService;
 import com.flab.musolmate.member.web.request.MemberRegisterRequest;
@@ -12,35 +13,37 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/members")
+@RequestMapping( "/members" )
 public class MemberApiController {
     private final MemberBasicService memberBasicService;
 
     /**
      * 회원가입
+     *
      * @param requestDto
      * @return
      */
-    @PostMapping("/register")
-    public ResponseEntity<Member> registerMember( @Valid @RequestBody MemberRegisterRequest requestDto) {
+    @PostMapping( "/register" )
+    public ResponseEntity< ApiResponse< Member > > registerMember( @Valid @RequestBody MemberRegisterRequest requestDto ) {
 
         Member registeredMember = memberBasicService.registerMember( requestDto );
-        return new ResponseEntity<>( registeredMember, HttpStatus.CREATED );
+        return ResponseEntity.status( HttpStatus.CREATED ).body( ApiResponse.createSuccess( registeredMember ) );
     }
 
-    @GetMapping("/{id}")
+    @GetMapping( "/{id}" )
     @PreAuthorize( "hasAnyAuthority('ROLE_ADMIN')" )
-    public ResponseEntity<Member> getMember( @PathVariable Long id ) {
+    public ResponseEntity< ApiResponse< Member > > getMember( @PathVariable Long id ) {
         Member member = memberBasicService.getMemberWithAuthorities( id ).orElse( null );
         if ( member == null ) {
             return new ResponseEntity<>( HttpStatus.NOT_FOUND ); // TODO. 커스텀 예외 처리
         }
-        return ResponseEntity.ok( member );
+        return ResponseEntity.status( HttpStatus.OK ).body( ApiResponse.createSuccess( member ) );
     }
 
-    @GetMapping("/me")
+    @GetMapping( "/me" )
     @PreAuthorize( "hasAnyAuthority('ROLE_USER')" )
-    public ResponseEntity<Member> getMyMember() {
-        return ResponseEntity.ok( memberBasicService.getMyMemberWithAthorities().get() );
+    public ResponseEntity< ApiResponse< Member > > getMyMember() {
+        Member member = memberBasicService.getMyMemberWithAthorities().orElse( null );
+        return ResponseEntity.status( HttpStatus.OK ).body( ApiResponse.createSuccess( member ) );
     }
 }

--- a/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
+++ b/src/main/java/com/flab/musolmate/member/web/MemberApiController.java
@@ -21,7 +21,7 @@ public class MemberApiController {
      * @param requestDto
      * @return
      */
-    @PostMapping
+    @PostMapping("/register")
     public ResponseEntity<Member> registerMember( @Valid @RequestBody MemberRegisterRequest requestDto) {
 
         Member registeredMember = memberBasicService.registerMember( requestDto );

--- a/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
+++ b/src/test/java/com/flab/musolmate/member/service/MemberBasicServiceTest.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static com.flab.musolmate.common.exception.ExceptionEnum.MESSAGE_DUPLICATE_MEMBER_EXCEPTION_EMAIL;
+import static com.flab.musolmate.common.exception.ExceptionEnum.MESSAGE_DUPLICATE_MEMBER_EXCEPTION_NICKNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -76,7 +78,7 @@ class MemberBasicServiceTest {
         // when
         assertThatThrownBy( () -> memberBasicService.registerMember( requestDto ) )
             .isInstanceOf( DuplicateMemberException.class )
-            .hasMessageContaining( "이미 가입한 회원입니다." );
+            .hasMessageContaining( MESSAGE_DUPLICATE_MEMBER_EXCEPTION_EMAIL );
 
     }
 
@@ -98,7 +100,7 @@ class MemberBasicServiceTest {
         // then
         assertThatThrownBy( () -> memberBasicService.registerMember( requestDto2 ) )
             .isInstanceOf( DuplicateMemberException.class )
-            .hasMessageContaining( "이미 존재하는 닉네임입니다." );
+            .hasMessageContaining( MESSAGE_DUPLICATE_MEMBER_EXCEPTION_NICKNAME );
 
     }
 

--- a/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/musolmate/member/web/MemberApiControllerTest.java
@@ -48,7 +48,7 @@ public class MemberApiControllerTest {
             .nickName( nickName )
             .build();
 
-        String url = "http://localhost:" + port + "/members";
+        String url = "http://localhost:" + port + "/members/register";
 
         // when
         ResponseEntity<Object> responseEntity = restTemplate.postForEntity( url, requestDto, Object.class );
@@ -70,7 +70,7 @@ public class MemberApiControllerTest {
             .nickName( nickName )
             .build();
 
-        String url = "http://localhost:" + port + "/members";
+        String url = "http://localhost:" + port + "/members/register";
 
         // when
         ResponseEntity<Member> responseEntity = restTemplate.postForEntity( url, requestDto, Member.class );


### PR DESCRIPTION
### 연관된 이슈
- #12 

### 작업 내용
#### 공통 응답 형식인 ApiResponse 생성
클라이언트에서 직관적으로 이해하고, 일관된 형식으로 에러를 처리할 수 있도록 공통 응답 형식 생성
```
{
 "status" : "success" || "fail" || "error",
 "code" : http status code + 00 
 "data" : { 성공시 응답객체 또는 배열 || 실패시 에러 원인 메시지 }
 }
```
위와 같은 구조로 API 요청시 응답값이 받아지도록 설계.
- code: 에러 발생시 Http Status 코드보다 더 상세하게, 상황에 따른 정보를 코드값으로 줄 수 있도록 5자리 숫자 사용
  -  예. 존재하지 않는 회원 조회시 40401
 - data: 성공시에는 클라이언트가 사용할 응답 객체, 실패시에는 실패한 원인을 작성. 에러의 경우 에러 메시지를 저장한다.
 
#### Exception Enum
위의 code 를 ExceptionEnum 클래스에서 상수로 관리
- 에러 메시지까지 함께 상수로 분리할지 고민중. 

#### ApiResponse 적용
- ExceptionAdvice : 기존에 ResponseEntity의 바다에 Map으로 직접 데이터를 반환하던 부분을 `ResponseEntity< ApiResponse< ? > >`를 반환하도록 수정
- 지금까지 만든 API의 응답값에 ApiResponse 적용
